### PR TITLE
Improve livereload browserify build; add less support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/**
+node_modules

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,22 +1,169 @@
-var gulp = require('gulp'),
-    browserify = require('gulp-browserify'),
-    livereload = require('gulp-livereload'),
-		babel = require("gulp-babel");
+var process = require('process');
+var gulp = require('gulp');
+var livereload = require('gulp-livereload');
+var browserify = require('browserify');
+var babelify = require('babelify');
+var watchify = require('watchify');
+var server = require('http-server');
+var del = require('del');
+var paths = require('vinyl-paths');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
+var clean = function(){ return paths( del ); };
+var notifier = require('node-notifier');
+var $ = require('gulp-load-plugins')();
+var runSequence = require('run-sequence');
+var pkg = require('./package.json');
+var deps = Object.keys( pkg.dependencies || {} );
 
-gulp.task('javascript', function() {
-  // Single entry point to browserify
-	gulp.src('src/js/app.js')
-		.pipe(browserify({
-		  	debug: true
-			}))
-		.pipe(babel())
-		.pipe(gulp.dest('./build/js'))
-		.pipe(livereload());
+var logError = function( err ){
+  notifier.notify({ title: pkg.name, message: 'Error: ' + err.message });
+  $.util.log( $.util.colors.red(err) );
+};
+
+var handleErr = function( err ){
+  logError( err );
+
+  if( this.emit ){
+    this.emit('end');
+  }
+};
+
+var getBrowserified = function( opts ){
+  opts = Object.assign( {
+    debug: true,
+    cache: {},
+    packageCache: {},
+    fullPaths: true,
+    bundleExternal: true,
+    entries: ['./src/js/app.js']
+  }, opts );
+
+  return browserify( opts ).on( 'log', $.util.log );
+};
+
+var transform = function( b ){
+  return ( b
+    .transform( babelify.configure({
+      presets: ['es2015', 'react'],
+      ignore: 'node_modules/**/*',
+      sourceMaps: 'inline'
+    }) )
+    .external( deps )
+  ) ;
+};
+
+var bundle = function( b ){
+  return ( b
+    .bundle()
+    .on( 'error', handleErr )
+    .pipe( source('app.js') )
+    .pipe( buffer() )
+  ) ;
+};
+
+gulp.task('js', function(){
+  return bundle( transform( getBrowserified() ) )
+    .pipe( gulp.dest('./build') )
+  ;
 });
 
-gulp.task('watch', function() {
-  livereload.listen();
-  gulp.watch('src/js/*.js', ['javascript']);
+gulp.task('js-deps', function(){
+  var b = browserify({
+    debug: false
+  });
+
+  deps.forEach(function( dep ){
+    b.require( dep );
+  });
+
+  return ( b
+    .bundle()
+    .on( 'error', handleErr )
+    .pipe( source('deps.js') )
+    .pipe( buffer() )
+    .pipe( gulp.dest('./build') )
+  ) ;
 });
 
-gulp.task('default', ['javascript', 'watch'], function() {});
+var less = function( s ){
+  return ( s
+    .pipe( $.sourcemaps.init() )
+
+    .pipe( $.less({
+      paths: ['./css'],
+      sourceMap: true,
+      relativeUrls: true,
+      sourceMapRootpath: '../',
+      sourceMapBasepath: process.cwd()
+    }) )
+      .on( 'error', handleErr )
+
+    .pipe( $.sourcemaps.write() )
+    .pipe( $.rename('app.css') )
+    .pipe( gulp.dest('./build') )
+  );
+};
+
+gulp.task('css', function(){
+  return less( gulp.src('./src/less/app.less') );
+});
+
+gulp.task('watch', ['css', 'js-deps'], function(){
+  $.livereload.listen({
+    basePath: process.cwd()
+  });
+
+  server.createServer({
+    root: './',
+    cache: -1,
+    cors: true
+  }).listen( '12345', '0.0.0.0' );
+
+  $.util.log( $.util.colors.green('App hosted on local HTTP server at http://localhost:12345') );
+
+  gulp.watch( ['./index.html', './build/deps.js', './build/app.js', './build/app.css'] )
+    .on('change', $.livereload.changed)
+  ;
+
+  gulp.src( './src/less/app.less' )
+    .pipe( $.plumber() )
+    .pipe( $.watchLess('./src/less/app.less', function(){
+      runSequence('css');
+    }) )
+    .on( 'error', handleErr )
+  ;
+
+  gulp.watch( ['./package.json'], ['js-deps'] );
+
+  var update = function(){
+    $.util.log( $.util.colors.white('JS rebuilding via watch...') );
+
+    bundle( b )
+      .pipe( gulp.dest('./build') )
+      .on('finish', function(){
+        $.util.log( $.util.colors.green('JS rebuild finished via watch') );
+      })
+    ;
+  };
+
+  var b = getBrowserified();
+
+  transform( b );
+
+  b.plugin( watchify, { poll: true } );
+
+  b.on( 'update', update );
+
+  update();
+});
+
+gulp.task('default', ['watch'], function( next ){
+  next();
+});
+
+gulp.task('clean', function(){
+  return gulp.src('./build')
+    .pipe( clean() )
+  ;
+});

--- a/index.html
+++ b/index.html
@@ -2,15 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-    <meta name="description" content="A grocery list application">
-    <meta name="author" content="">
-    <title></title>
+    <title>Grocery List</title>
+
+    <link rel="stylesheet" href="./build/app.css" />
+
+    <script src="http://localhost:35729/livereload.js"></script>
+
+    <script src="./build/deps.js"></script>
+    <script src="./build/app.js"></script>
   </head>
   <body>
-    <script type="text/javascript" src="build/js/app.js"></script>    
+
+
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "description": "Programming task for web application developers",
   "scripts": {
-    "start": "gulp default"
+    "start": "gulp watch",
+    "watch": "gulp watch",
+    "clean": "gulp clean"
   },
   "keywords": [
     "web",
@@ -12,9 +14,29 @@
   ],
   "author": "",
   "devDependencies": {
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.11.1",
+    "babelify": "^7.3.0",
+    "browserify": "^13.0.1",
+    "del": "^2.2.1",
     "gulp": "^3.9.1",
-    "gulp-browserify": "^0.5.1",
+    "gulp-less": "^3.1.0",
     "gulp-livereload": "^3.8.1",
-    "gulp-babel": "^6.1.2"
+    "gulp-load-plugins": "^1.2.4",
+    "gulp-plumber": "^1.1.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-util": "^3.0.7",
+    "gulp-watch-less": "^1.0.1",
+    "http-server": "^0.9.0",
+    "node-notifier": "^4.6.0",
+    "run-sequence": "^1.2.2",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-paths": "^2.1.0",
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.7.0"
+  },
+  "dependencies": {
+    "lodash": "^4.13.1"
   }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,2 +1,3 @@
-var message = 'Please implement your Grocery List!';
-console.info(message);
+// this is the main js file; require() or es6 import other files from here
+
+console.log('impl todo');

--- a/src/less/app.less
+++ b/src/less/app.less
@@ -1,0 +1,3 @@
+// this is the main less file; @import other less files you want in the app
+
+// style TODO


### PR DESCRIPTION
- Allows watch rebuilding to work performantly even if several large libs `require()`d
- Allows use of LESS CSS preprocessor
- Adds clean target
- Watch performance greatly increased
- Watch gives nice update messages
- Includes ES2015 support via latest Babel
- Includes JSX support for people who want to use React
- Adds HTTP server when watching to make debugging easier and faster for candidates
